### PR TITLE
Benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ env-down:
 test:
 	docker exec research-online-postgres-go-app go test ./... -v -count=1
 
+bench:
+	docker exec research-online-postgres-go-app go test ./... -v -run=$$^ -bench=. -benchmem -benchtime=1000x
+
 go-test-run:
 	docker exec research-online-postgres-go-app go run main.go
 

--- a/batch_update_online_storage_test.go
+++ b/batch_update_online_storage_test.go
@@ -27,3 +27,20 @@ func TestBatchUpdateOnlineStorage(t *testing.T) {
 
 	testOnlineStorage(t, storage)
 }
+
+func BenchmarkBatchUpdateOnlineStorage(b *testing.B) {
+	b.Helper()
+	if testing.Short() {
+		b.Skip()
+	}
+
+	ctx := context.Background()
+
+	connection, err := pgx.Connect(ctx, dataSourceName)
+	require.NoError(b, err)
+	defer connection.Close(ctx)
+
+	storage := NewBatchUpdateOnlineStorage(postgresql.NewSqlcRepository(connection))
+
+	benchmarkOnlineStorage(b, storage)
+}

--- a/batch_upsert_online_storage_test.go
+++ b/batch_upsert_online_storage_test.go
@@ -27,3 +27,20 @@ func TestBatchUpsertOnlineStorage(t *testing.T) {
 
 	testOnlineStorage(t, storage)
 }
+
+func BenchmarkBatchUpsertOnlineStorage(b *testing.B) {
+	b.Helper()
+	if testing.Short() {
+		b.Skip()
+	}
+
+	ctx := context.Background()
+
+	connection, err := pgx.Connect(ctx, dataSourceName)
+	require.NoError(b, err)
+	defer connection.Close(ctx)
+
+	storage := NewBatchUpsertOnlineStorage(postgresql.NewSqlcRepository(connection))
+
+	benchmarkOnlineStorage(b, storage)
+}

--- a/update_online_storage_test.go
+++ b/update_online_storage_test.go
@@ -27,3 +27,20 @@ func TestUpdateOnlineStorage(t *testing.T) {
 
 	testOnlineStorage(t, storage)
 }
+
+func BenchmarkUpdateOnlineStorage(b *testing.B) {
+	b.Helper()
+	if testing.Short() {
+		b.Skip()
+	}
+
+	ctx := context.Background()
+
+	connection, err := pgx.Connect(ctx, dataSourceName)
+	require.NoError(b, err)
+	defer connection.Close(ctx)
+
+	storage := NewUpdateOnlineStorage(postgresql.NewSqlcRepository(connection))
+
+	benchmarkOnlineStorage(b, storage)
+}

--- a/upsert_online_storage_test.go
+++ b/upsert_online_storage_test.go
@@ -27,3 +27,20 @@ func TestUpsertOnlineStorage(t *testing.T) {
 
 	testOnlineStorage(t, storage)
 }
+
+func BenchmarkUpsertOnlineStorage(b *testing.B) {
+	b.Helper()
+	if testing.Short() {
+		b.Skip()
+	}
+
+	ctx := context.Background()
+
+	connection, err := pgx.Connect(ctx, dataSourceName)
+	require.NoError(b, err)
+	defer connection.Close(ctx)
+
+	storage := NewUpsertOnlineStorage(postgresql.NewSqlcRepository(connection))
+
+	benchmarkOnlineStorage(b, storage)
+}


### PR DESCRIPTION
```bash
docker exec research-online-postgres-go-app go test ./... -v -run=$^ -bench=. -benchmem -benchtime=1000x
```
```text
goos: linux
goarch: amd64
pkg: github.com/doutivity/research-online-postgres-go
cpu: Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
BenchmarkBatchUpdateOnlineStorage
BenchmarkBatchUpdateOnlineStorage-12    	    1000	   8547540 ns/op	  234932 B/op	    2027 allocs/op
BenchmarkBatchUpsertOnlineStorage
BenchmarkBatchUpsertOnlineStorage-12    	    1000	   9681665 ns/op	  234934 B/op	    2027 allocs/op
BenchmarkUpdateOnlineStorage
BenchmarkUpdateOnlineStorage-12         	    1000	  71251563 ns/op	  160056 B/op	    5003 allocs/op
BenchmarkUpsertOnlineStorage
BenchmarkUpsertOnlineStorage-12         	    1000	  81117529 ns/op	  168053 B/op	    5003 allocs/op
PASS
ok  	github.com/doutivity/research-online-postgres-go	189.523s
```
```sql
SELECT COUNT(*),
       SUM(
               CASE online
                   WHEN TO_TIMESTAMP(1679800725) THEN 0
                   ELSE 1
                   END
           )
FROM user_online;
```
```sql
TRUNCATE TABLE user_online;
```
```sql
INSERT INTO user_online (user_id, online)
SELECT generate_series,
       to_timestamp(1679800725)
FROM generate_series(1, 100 * 1000)
ON CONFLICT (user_id) DO UPDATE
    SET online = excluded.online;
```